### PR TITLE
Fix a loop index in SetupConfig.

### DIFF
--- a/src/wayland/wayland-fbconfig.c
+++ b/src/wayland/wayland-fbconfig.c
@@ -233,7 +233,7 @@ static EGLBoolean SetupConfig(EplPlatformData *plat,
         {
             for (j=0; j<driver_fmt->num_modifiers && !supported; j++)
             {
-                if (server_fmt->modifiers[i] == driver_fmt->modifiers[i])
+                if (server_fmt->modifiers[i] == driver_fmt->modifiers[j])
                 {
                     supported = EGL_TRUE;
                 }


### PR DESCRIPTION
This just fixes a typo in `SetupConfig`, where it's using the wrong index variable for one of the arrays.