### PR TITLE
Fix a few build errors

### DIFF
--- a/src/wayland/wayland-fbconfig.c
+++ b/src/wayland/wayland-fbconfig.c
@@ -182,7 +182,7 @@ static EGLBoolean SetupConfig(EplPlatformData *plat,
     const WlDmaBufFormat *server_fmt = NULL;
     EGLint fourcc = DRM_FORMAT_INVALID;
     EGLBoolean supported = EGL_FALSE;
-    EGLint i, j;
+    size_t i, j;
 
     config->surfaceMask &= ~(EGL_WINDOW_BIT | EGL_PIXMAP_BIT);
 

--- a/src/wayland/wayland-surface.c
+++ b/src/wayland/wayland-surface.c
@@ -690,7 +690,7 @@ static void WindowUpdateCallback(void *param)
     }
 }
 
-static const uint32_t FindOpaqueFormat(const EplFormatInfo *fmt)
+static uint32_t FindOpaqueFormat(const EplFormatInfo *fmt)
 {
     int i;
 
@@ -1388,9 +1388,12 @@ EGLBoolean eplWlSwapBuffers(EplPlatformData *plat, EplDisplay *pdpy,
                 uint64_t timestamp = ((uint64_t) swap_interval) * psurf->priv->current.last_present_refresh;
                 if (timestamp >= FRAME_TIMESTAMP_PADDING)
                 {
+                    uint64_t sec;
+                    uint32_t nsec;
+
                     timestamp += psurf->priv->current.last_present_timestamp - FRAME_TIMESTAMP_PADDING;
-                    uint64_t sec = timestamp / 1000000000;
-                    uint32_t nsec = timestamp % 1000000000;
+                    sec = timestamp / 1000000000;
+                    nsec = timestamp % 1000000000;
                     wp_commit_timer_v1_set_timestamp(psurf->priv->current.commit_timer,
                             (uint32_t) (sec >> 32), (uint32_t) sec, nsec);
                 }

--- a/src/wayland/wayland-swapchain.c
+++ b/src/wayland/wayland-swapchain.c
@@ -34,7 +34,7 @@
 /**
  * The maximum number of color buffers to allocate for a window.
  */
-static const int MAX_PRESENT_BUFFERS = 4;
+static const size_t MAX_PRESENT_BUFFERS = 4;
 
 /**
  * How long to wait for a buffer release before we stop to check for window

--- a/src/wayland/wayland-swapchain.h
+++ b/src/wayland/wayland-swapchain.h
@@ -107,8 +107,8 @@ typedef struct
     /**
      * The size of the buffers.
      */
-    EGLint width;
-    EGLint height;
+    uint32_t width;
+    uint32_t height;
 
     uint32_t render_fourcc;
 

--- a/src/wayland/wl-object-utils.c
+++ b/src/wayland/wl-object-utils.c
@@ -62,6 +62,7 @@ EGLBoolean wlEglCheckInterfaceType(struct wl_object *obj, const char *ifname)
 {
     /* The first member of a wl_object is a pointer to its wl_interface, */
     struct wl_interface *interface;
+    size_t len;
 
     if (!wlEglMemoryIsReadable(obj, sizeof(void *)))
     {
@@ -72,7 +73,7 @@ EGLBoolean wlEglCheckInterfaceType(struct wl_object *obj, const char *ifname)
 
     /* Check if the memory for the wl_interface struct, and the
      * interface name, are safe to read. */
-    int len = strlen(ifname);
+    len = strlen(ifname);
     if (!wlEglMemoryIsReadable(interface, sizeof (*interface))
             || !wlEglMemoryIsReadable(interface->name, len + 1))
     {


### PR DESCRIPTION
This fixes a few signed/unsigned mismatches (which can trigger compiler warnings) and some places with mixed declarations and code (which older compilers don't allow).