### PR TITLE
Set version number to 1.0.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 project('nvidia-egl-wayland2', 'c',
-  version : '0.1',
+  version : '1.0.0',
   default_options : ['c_std=gnu99'],
 )
 

--- a/src/wayland/09_nvidia_wayland2.json
+++ b/src/wayland/09_nvidia_wayland2.json
@@ -1,6 +1,6 @@
 {
     "file_format_version" : "1.0.0",
     "ICD" : {
-        "library_path" : "libnvidia-egl-wayland2.so.0"
+        "library_path" : "libnvidia-egl-wayland2.so.1"
     }
 }


### PR DESCRIPTION
We've still got a lot more testing to do before actually tagging a release, but this sets the version number in the Meson script for when we eventually do.