### PR TITLE
egl-wayland2: close dmabuf format table fd

### DIFF
--- a/src/wayland/wayland-dmabuf.c
+++ b/src/wayland/wayland-dmabuf.c
@@ -21,6 +21,7 @@
 #include <string.h>
 #include <sys/mman.h>
 #include <assert.h>
+#include <unistd.h>
 
 #include <drm_fourcc.h>
 
@@ -106,6 +107,8 @@ void eplWlDmaBufFeedbackCommonFormatTable(void *userdata,
             base->error = EGL_TRUE;
         }
     }
+
+    close(fd);
 }
 
 void eplWlDmaBufFeedbackCommonMainDevice(void *userdata,


### PR DESCRIPTION
The compositor sends us a memfd for the format table, we need to actually close it once we are done. This is causing an fd leak on KDE which is crashing plasmashell after a couple minutes.