### PR TITLE
Update the wl_egl_window attached size.

### DIFF
--- a/src/wayland/wayland-surface.c
+++ b/src/wayland/wayland-surface.c
@@ -1455,6 +1455,14 @@ EGLBoolean eplWlSwapBuffers(EplPlatformData *plat, EplDisplay *pdpy,
 
     wl_surface_commit(psurf->priv->current.wsurf);
 
+    pthread_mutex_lock(&psurf->priv->params.mutex);
+    if (psurf->priv->params.native_window != NULL)
+    {
+        psurf->priv->params.native_window->attached_width = psurf->priv->current.swapchain->width;
+        psurf->priv->params.native_window->attached_height = psurf->priv->current.swapchain->height;
+    }
+    pthread_mutex_unlock(&psurf->priv->params.mutex);
+
     /*
      * Send a wl_display::sync request after the commit.
      *


### PR DESCRIPTION
In eglSwapBuffers, after we commit a new buffer to the window, we need to record the buffer size in the wl_egl_window struct.