### PR TITLE
egl-wayland2: Fix libdrm loading when wl_drm is not available

### DIFF
--- a/src/wayland/wayland-platform.h
+++ b/src/wayland/wayland-platform.h
@@ -61,6 +61,7 @@ struct _EplImplPlatform
 
     struct
     {
+        void *libdrmDlHandle;
         int (* GetDeviceFromDevId) (dev_t dev_id, uint32_t flags, drmDevicePtr *device);
         int (* GetCap) (int fd, uint64_t capability, uint64_t *value);
         int (* SyncobjCreate) (int fd, uint32_t flags, uint32_t *handle);


### PR DESCRIPTION
If the compositor does not support wl_drm and we fail to get the drmGetDeviceFromDevId symbol then the driver load will fail. This happens with steam due to it hijacking dlopen/dlsym. This change has us directly dlopen libdrm and get a symbol from it instead of relying on RTLD_DEFAULT.

This is the egl-wayland2 equivalent of: https://github.com/NVIDIA/egl-wayland/pull/177