### PR TITLE
Remove a stray abort() in eplWlCreateWindowSurface.

### DIFF
--- a/src/wayland/wayland-surface.c
+++ b/src/wayland/wayland-surface.c
@@ -855,7 +855,6 @@ EGLSurface eplWlCreateWindowSurface(EplPlatformData *plat, EplDisplay *pdpy, Epl
     else
     {
         priv->current.queue = wl_display_create_queue(inst->wdpy);
-        abort();
     }
     if (priv->current.queue == NULL)
     {


### PR DESCRIPTION
This removes an `abort()` call when `wl_display_create_queue_with_name` isn't available. I think that was left over from testing -- we handle that case just fine.