### PR TITLE
Fix the version check for wl_surface.

### DIFF
--- a/src/wayland/wayland-dmabuf.c
+++ b/src/wayland/wayland-dmabuf.c
@@ -383,7 +383,8 @@ EGLBoolean GetDefaultFeedbackV4(DefaultFeedbackState *state,
 
     glvnd_list_init(&state->tranches);
 
-    assert(wl_proxy_get_version((struct wl_proxy *) wdmabuf) >= 4);
+    assert(wl_proxy_get_version((struct wl_proxy *) wdmabuf)
+            >= ZWP_LINUX_DMABUF_V1_GET_DEFAULT_FEEDBACK_SINCE_VERSION);
 
     queue = wl_display_create_queue(wdpy);
     if (queue == NULL)
@@ -500,11 +501,11 @@ WlFormatList *eplWlDmaBufFeedbackGetDefault(struct wl_display *wdpy,
     glvnd_list_init(&state.tranches);
     wl_array_init(&state.tranche_formats);
 
-    if (version >= 4)
+    if (version >= ZWP_LINUX_DMABUF_V1_GET_DEFAULT_FEEDBACK_SINCE_VERSION)
     {
         success = GetDefaultFeedbackV4(&state, wdpy, wdmabuf);
     }
-    else if (version >= 3)
+    else if (version >= ZWP_LINUX_DMABUF_V1_MODIFIER_SINCE_VERSION)
     {
         success = GetDefaultFeedbackV3(&state, wdpy, wdmabuf, queue);
     }

--- a/src/wayland/wayland-surface.c
+++ b/src/wayland/wayland-surface.c
@@ -450,7 +450,8 @@ static EGLBoolean CreateSurfaceFeedback(EplSurface *psurf)
     SurfaceFeedbackState *state;
     struct zwp_linux_dmabuf_v1 *wrapper = NULL;
 
-    if (inst->force_prime || wl_proxy_get_version((struct wl_proxy *) inst->globals.dmabuf) < 4)
+    if (inst->force_prime || wl_proxy_get_version((struct wl_proxy *) inst->globals.dmabuf)
+            < ZWP_LINUX_DMABUF_V1_GET_SURFACE_FEEDBACK_SINCE_VERSION)
     {
         return EGL_TRUE;
     }
@@ -1349,7 +1350,8 @@ EGLBoolean eplWlSwapBuffers(EplPlatformData *plat, EplDisplay *pdpy,
     assert(psurf->priv->current.last_swap_sync == NULL);
 
     if (rects != NULL && n_rects > 0
-            && wl_proxy_get_version((struct wl_proxy *) psurf->priv->current.wsurf) >= 3)
+            && wl_proxy_get_version((struct wl_proxy *) psurf->priv->current.wsurf)
+                >= WL_SURFACE_DAMAGE_BUFFER_SINCE_VERSION)
     {
         EGLint i;
         for (i=0; i<n_rects; i++)


### PR DESCRIPTION
This fixes the version check for whether `wl_surface::damage_buffer` is available. Right now, it's checking for version >= 3, but that request was added in version 4.

This change fixes that, and changes all of the version checks to use the `*_SINCE_VERSION` constants instead of hard-coding version numbers.