### PR TITLE
Fix an incorrect return statement in eplWlSwapBuffers.

### DIFF
--- a/src/wayland/wayland-surface.c
+++ b/src/wayland/wayland-surface.c
@@ -1348,7 +1348,7 @@ EGLBoolean eplWlSwapBuffers(EplPlatformData *plat, EplDisplay *pdpy,
     {
         if (!WaitForPreviousFrames(psurf))
         {
-            return EGL_FALSE;
+            goto done;
         }
     }
     else


### PR DESCRIPTION
This fixes a stray return statement in `eplWlSwapBuffers`, which would cause it to skip all of the cleanup stuff that we need to do.