### PR TITLE
Remove SurfaceFeedbackState::modifiers_changed

### DIFF
--- a/src/wayland/wayland-swapchain.h
+++ b/src/wayland/wayland-swapchain.h
@@ -175,6 +175,8 @@ typedef struct
      * An event queue used internally by the swap chain itself.
      */
     struct wl_event_queue *queue;
+
+    uint32_t feedback_update_count;
 } WlSwapChain;
 
 /**


### PR DESCRIPTION
This removes the `SurfaceFeedbackState::modifiers_changed` flag that we currently set when we get a new batch of surface dma-buf feedback data.

But, that flag isn't especially useful since we never *clear* it, and there isn't really a good place to do so.

Instead, this will just scan the list of supported modifiers each time eglSwapBuffers is called to check if the current modifier is still valid. While it would be possible to cache that better, unconditionally scanning the list keeps things simpler, and the modifier list will have about a dozen elements in it, tops.