### PR TITLE
Don't use the wl_display during teardown.

### DIFF
--- a/src/wayland/wayland-display.h
+++ b/src/wayland/wayland-display.h
@@ -180,4 +180,14 @@ void eplWlTerminateDisplay(EplPlatformData *plat, EplDisplay *pdpy);
 
 const char *eplWlHookQueryString(EGLDisplay edpy, EGLint name);
 
+/**
+ * Returns true if the native display is still expected to be valid.
+ *
+ * This will return false during teardown for an application-owned wl_display.
+ * Some applications will call wl_display_disconnect but not eglTerminate
+ * before they terminate, in which trying to do anything with the wl_display
+ * could cause a crash or hang.
+ */
+EGLBoolean eplWlDisplayInstanceIsNativeValid(WlDisplayInstance *inst);
+
 #endif // WAYLAND_DISPLAY_H

--- a/src/wayland/wayland-surface.c
+++ b/src/wayland/wayland-surface.c
@@ -509,7 +509,8 @@ static void DestroySurfaceFeedback(EplSurface *psurf)
 {
     if (psurf->priv->current.feedback != NULL)
     {
-        if (psurf->priv->current.feedback->feedback != NULL)
+        if (psurf->priv->current.feedback->feedback != NULL
+                && eplWlDisplayInstanceIsNativeValid(psurf->priv->inst))
         {
             zwp_linux_dmabuf_feedback_v1_destroy(psurf->priv->current.feedback->feedback);
         }
@@ -1069,11 +1070,6 @@ void eplWlDestroyWindow(EplDisplay *pdpy, EplSurface *psurf,
         psurf->internal_surface = EGL_NO_SURFACE;
     }
 
-    if (psurf->priv->current.wsurf != NULL)
-    {
-        wl_proxy_wrapper_destroy(psurf->priv->current.wsurf);
-    }
-
     if (psurf->priv->params.native_window != NULL)
     {
         psurf->priv->params.native_window->resize_callback = NULL;
@@ -1091,37 +1087,44 @@ void eplWlDestroyWindow(EplDisplay *pdpy, EplSurface *psurf,
 
     DestroySurfaceFeedback(psurf);
 
-    if (psurf->priv->current.syncobj != NULL)
+    if (eplWlDisplayInstanceIsNativeValid(pdpy->priv->inst))
     {
-        wp_linux_drm_syncobj_surface_v1_destroy(psurf->priv->current.syncobj);
-    }
-    if (psurf->priv->current.frame_callback != NULL)
-    {
-        wl_callback_destroy(psurf->priv->current.frame_callback);
-    }
-    if (psurf->priv->current.last_swap_sync != NULL)
-    {
-        wl_callback_destroy(psurf->priv->current.last_swap_sync);
-    }
-    if (psurf->priv->current.presentation_feedback != NULL)
-    {
-        wp_presentation_feedback_destroy(psurf->priv->current.presentation_feedback);
-    }
-    if (psurf->priv->current.fifo != NULL)
-    {
-        wp_fifo_v1_destroy(psurf->priv->current.fifo);
-    }
-    if (psurf->priv->current.commit_timer != NULL)
-    {
-        wp_commit_timer_v1_destroy(psurf->priv->current.commit_timer);
-    }
-    if (psurf->priv->current.presentation_time != NULL)
-    {
-        wl_proxy_wrapper_destroy(psurf->priv->current.presentation_time);
-    }
-    if (psurf->priv->current.queue != NULL)
-    {
-        wl_event_queue_destroy(psurf->priv->current.queue);
+        if (psurf->priv->current.wsurf != NULL)
+        {
+            wl_proxy_wrapper_destroy(psurf->priv->current.wsurf);
+        }
+        if (psurf->priv->current.syncobj != NULL)
+        {
+            wp_linux_drm_syncobj_surface_v1_destroy(psurf->priv->current.syncobj);
+        }
+        if (psurf->priv->current.frame_callback != NULL)
+        {
+            wl_callback_destroy(psurf->priv->current.frame_callback);
+        }
+        if (psurf->priv->current.last_swap_sync != NULL)
+        {
+            wl_callback_destroy(psurf->priv->current.last_swap_sync);
+        }
+        if (psurf->priv->current.presentation_feedback != NULL)
+        {
+            wp_presentation_feedback_destroy(psurf->priv->current.presentation_feedback);
+        }
+        if (psurf->priv->current.fifo != NULL)
+        {
+            wp_fifo_v1_destroy(psurf->priv->current.fifo);
+        }
+        if (psurf->priv->current.commit_timer != NULL)
+        {
+            wp_commit_timer_v1_destroy(psurf->priv->current.commit_timer);
+        }
+        if (psurf->priv->current.presentation_time != NULL)
+        {
+            wl_proxy_wrapper_destroy(psurf->priv->current.presentation_time);
+        }
+        if (psurf->priv->current.queue != NULL)
+        {
+            wl_event_queue_destroy(psurf->priv->current.queue);
+        }
     }
 
     pthread_mutex_destroy(&psurf->priv->params.mutex);

--- a/src/wayland/wayland-swapchain.c
+++ b/src/wayland/wayland-swapchain.c
@@ -46,7 +46,7 @@ static void DestroyPresentBuffer(WlDisplayInstance *inst, WlPresentBuffer *buffe
 {
     if (buffer != NULL)
     {
-        if (buffer->wbuf != NULL)
+        if (buffer->wbuf != NULL && eplWlDisplayInstanceIsNativeValid(inst))
         {
             wl_buffer_destroy(buffer->wbuf);
         }
@@ -298,7 +298,7 @@ void eplWlSwapChainDestroy(WlDisplayInstance *inst, WlSwapChain *swapchain)
             DestroyPresentBuffer(inst, buffer);
         }
 
-        if (swapchain->queue != NULL)
+        if (swapchain->queue != NULL && eplWlDisplayInstanceIsNativeValid(inst))
         {
             wl_event_queue_destroy(swapchain->queue);
         }

--- a/src/wayland/wayland-timeline.c
+++ b/src/wayland/wayland-timeline.c
@@ -82,7 +82,10 @@ void eplWlTimelineDestroy(WlDisplayInstance *inst, WlTimeline *timeline)
 {
     if (timeline->wtimeline != NULL)
     {
-        wp_linux_drm_syncobj_timeline_v1_destroy(timeline->wtimeline);
+        if (eplWlDisplayInstanceIsNativeValid(inst))
+        {
+            wp_linux_drm_syncobj_timeline_v1_destroy(timeline->wtimeline);
+        }
 
         inst->platform->priv->drm.SyncobjDestroy(
                 gbm_device_get_fd(inst->gbmdev),


### PR DESCRIPTION
This changes the eplWlDestroyWindow and eplWlDisplayInstanceFree so that if we're going through teardown, it won't try to do anything with the native wl_display.

This is a workaround for applications that call `wl_display_disconnect` but not `eglTerminate` before they exit. Currently, egl-wayland2 will try to go through the same code as eglTerminate to clean up, which will then crash or hang when it tries to use the application's wl_display.
