### PR TITLE
Fix building on FreeBSD

### DIFF
--- a/src/wayland/wayland-swapchain.c
+++ b/src/wayland/wayland-swapchain.c
@@ -705,7 +705,7 @@ static int CheckBufferReleaseImplicit(WlDisplayInstance *inst,
         }
         return count;
     }
-    else if (ret == 0 || errno == ETIME || errno == EINTR)
+    else if (ret == 0 || errno == EINTR)
     {
         // Nothing freed up before the timeout, but that's not a fatal error
         // here.

--- a/src/wayland/wayland-swapchain.h
+++ b/src/wayland/wayland-swapchain.h
@@ -32,6 +32,11 @@
 #include "wayland-platform.h"
 #include "wayland-timeline.h"
 
+// FreeBSD doesn't have ETIME, so the DRM calls return ETIMEDOUT instead.
+#ifndef ETIME
+#define ETIME ETIMEDOUT
+#endif
+
 typedef enum
 {
     /**


### PR DESCRIPTION
FreeBSD doesn't use ETIME, so this adds a `#define` to replace that with ETIMEDOUT.

This also removes the check for ETIME after calling `poll`, since poll doesn't use ETIME.