### PR TITLE
Fix NULL pointer passed to wl_event_queue_destroy

### DIFF
--- a/src/wayland/wayland-display.c
+++ b/src/wayland/wayland-display.c
@@ -1127,7 +1127,10 @@ WlDisplayInstance *eplWlDisplayInstanceCreate(EplDisplay *pdpy, EGLBoolean from_
 
 done:
     FreeDisplayRegistry(&names);
-    wl_event_queue_destroy(queue);
+    if (queue != NULL)
+    {
+        wl_event_queue_destroy(queue);
+    }
     free(drmNode);
     if (drmFd >= 0)
     {


### PR DESCRIPTION
In eplWlDisplayInstanceCreate, the queue variable may remain NULL if an error occurs before an event queue is successfully created. The cleanup code at the done label would then pass NULL to wl_event_queue_destroy, which does not safely handle NULL pointers.

Add a NULL check before calling wl_event_queue_destroy to prevent this.