### PR TITLE
base library: Replace EplImplFuncs::QueryBufferAge with a more general QuerySurface function

### DIFF
--- a/src/base/platform-base.c
+++ b/src/base/platform-base.c
@@ -1233,13 +1233,22 @@ static EGLBoolean HookQueryDisplayAttrib(EGLDisplay edpy, EGLint attribute, EGLA
         *value = (EGLAttrib) pdpy->track_references;
         ret = EGL_TRUE;
     }
-    else if (pdpy->platform->impl->QueryDisplayAttrib != NULL)
-    {
-        ret = pdpy->platform->impl->QueryDisplayAttrib(pdpy, attribute, value);
-    }
     else
     {
-        ret = pdpy->platform->egl.QueryDisplayAttribEXT(pdpy->internal_display, attribute, value);
+        EplQueryResult result = EPL_QUERY_RESULT_UNKNOWN;
+        if (pdpy->platform->impl->QueryDisplayAttrib != NULL)
+        {
+            result = pdpy->platform->impl->QueryDisplayAttrib(pdpy, attribute, value);
+        }
+
+        if (result == EPL_QUERY_RESULT_UNKNOWN)
+        {
+            ret = pdpy->platform->egl.QueryDisplayAttribEXT(pdpy->internal_display, attribute, value);
+        }
+        else
+        {
+            ret = (result == EPL_QUERY_RESULT_SUCCESS);
+        }
     }
 
     eplDisplayRelease(pdpy);
@@ -1321,25 +1330,27 @@ static EGLBoolean HookQuerySurface(EGLDisplay edpy, EGLSurface esurf, EGLint att
 
     if (psurf != NULL)
     {
+        EplQueryResult result = EPL_QUERY_RESULT_UNKNOWN;
+
         if (attribute == EGL_BUFFER_AGE_KHR)
         {
+            // Querying EGL_BUFFER_AGE_KHR is only valid for the current
+            // EGLSurface.
             if (pdpy->platform->egl.GetCurrentSurface(EGL_DRAW) != esurf)
             {
                 eplSetError(pdpy->platform, EGL_BAD_SURFACE, "EGLSurface %p is not current", esurf);
                 goto done;
             }
+        }
 
-            if (pdpy->platform->impl->QueryBufferAge != NULL)
-            {
-                EGLint age = pdpy->platform->impl->QueryBufferAge(pdpy, psurf);
-                if (age < 0)
-                {
-                    goto done;
-                }
+        if (pdpy->platform->impl->QuerySurface != NULL)
+        {
+            result = pdpy->platform->impl->QuerySurface(pdpy, psurf, attribute, value);
+        }
 
-                *value = age;
-            }
-            else
+        if (result == EPL_QUERY_RESULT_UNKNOWN)
+        {
+            if (attribute == EGL_BUFFER_AGE_KHR)
             {
                 /*
                  * If the platform code doesn't implement this, then just return
@@ -1347,17 +1358,24 @@ static EGLBoolean HookQuerySurface(EGLDisplay edpy, EGLSurface esurf, EGLint att
                  * make any assumptions about the buffer's contents.
                  */
                 *value = 0;
+                ret = EGL_TRUE;
             }
-
-            psurf->bufferAgeCalled = EGL_TRUE;
-            ret = EGL_TRUE;
+            else
+            {
+                // If it's not an attribute that we recognize, then pass the query
+                // through to the driver.
+                ret = pdpy->platform->egl.QuerySurface(pdpy->internal_display,
+                        psurf->internal_surface, attribute, value);
+            }
         }
         else
         {
-            // If it's not an attribute that we recognize, then pass the query
-            // through to the driver.
-            ret = pdpy->platform->egl.QuerySurface(pdpy->internal_display,
-                    psurf->internal_surface, attribute, value);
+            ret = (result == EPL_QUERY_RESULT_SUCCESS);
+        }
+
+        if (ret && attribute == EGL_BUFFER_AGE_KHR)
+        {
+            psurf->bufferAgeCalled = EGL_TRUE;
         }
     }
     else

--- a/src/base/platform-impl.h
+++ b/src/base/platform-impl.h
@@ -36,6 +36,31 @@ extern "C" {
 #endif
 
 /**
+ * This is the return value used for EplImplFuncs::QuerySurface.
+ */
+typedef enum
+{
+    /**
+     * The platform library doesn't recognize the attribute. In this case, the
+     * base library will pass the query through to the driver.
+     */
+    EPL_QUERY_RESULT_UNKNOWN,
+
+    /**
+     * The platform library recognized and returned the attribute.
+     */
+    EPL_QUERY_RESULT_SUCCESS,
+
+    /**
+     * The platform library recognized the attribute, but there was some error
+     * returning the value.
+     *
+     * The platform library should set the EGL error code before returning.
+     */
+    EPL_QUERY_RESULT_ERROR,
+} EplQueryResult;
+
+/**
  * A table of functions for the platform-specific implementation.
  */
 typedef struct _EplImplFuncs
@@ -287,9 +312,9 @@ typedef struct _EplImplFuncs
      * \param pdpy The EplDisplay struct
      * \param attrib The attribute to look up.
      * \param[out] value Returns the value of the attribute.
-     * \return EGL_TRUE on success, EGL_FALSE on failure.
+     * \return An \c EplQueryResult value.
      */
-    EGLBoolean (*QueryDisplayAttrib) (EplDisplay *pdpy, EGLint attrib, EGLAttrib *ret_value);
+    EplQueryResult (*QueryDisplayAttrib) (EplDisplay *pdpy, EGLint attrib, EGLAttrib *ret_value);
 
     /**
      * Implements eglSwapInterval.
@@ -311,16 +336,23 @@ typedef struct _EplImplFuncs
     EGLBoolean (* SwapInterval) (EplDisplay *pdpy, EplSurface *psurf, EGLint interval);
 
     /**
-     * Returns the value of EGL_BUFFER_AGE_KHR.
+     * Implements eglQuerySurface for any platform-specific attributes.
      *
      * This function is optional. If it's NULL, then the base library will just
-     * return zero.
+     * act as if the platform returned EPL_QUERY_RESULT_UNKNOWN.
+     *
+     * Note that the base library handles the error checking for
+     * EGL_EXT_buffer_age and EGL_KHR_partial_update internally. If \p attrib
+     * is \c EGL_BUFFER_AGE_KHR, then the platform can assume that the surface
+     * is current.
      *
      * \param pdpy The current display.
      * \param psurf The current draw surface. This will never be NULL.
-     * \return The buffer age, or -1 on error.
+     * \param attrib The attribute to look up.
+     * \param[out] value Returns the value of the attribute.
+     * \return An \c EplQueryResult value.
      */
-    EGLint (* QueryBufferAge) (EplDisplay *pdpy, EplSurface *psurf);
+    EplQueryResult (* QuerySurface) (EplDisplay *pdpy, EplSurface *psurf, EGLint attrib, EGLint *ret_value);
 
     /**
      * Implements eglSetDamageRegionKHR.

--- a/src/wayland/wayland-platform.c
+++ b/src/wayland/wayland-platform.c
@@ -59,7 +59,7 @@ static const EplImplFuncs WL_IMPL_FUNCS =
     .SwapBuffers = eplWlSwapBuffers,
     .WaitGL = eplWlWaitGL,
     .SwapInterval = eplWlSwapInterval,
-    .QueryBufferAge = eplWlQueryBufferAge,
+    .QuerySurface = eplWlQuerySurface,
 };
 
 static EGLBoolean LoadProcHelper(EplPlatformData *plat, void *handle, void **ptr, const char *name)

--- a/src/wayland/wayland-platform.h
+++ b/src/wayland/wayland-platform.h
@@ -142,6 +142,6 @@ EGLBoolean eplWlSwapInterval(EplDisplay *pdpy, EplSurface *psurf, EGLint interva
 
 EGLBoolean eplWlWaitGL(EplDisplay *pdpy, EplSurface *psurf);
 
-EGLint eplWlQueryBufferAge(EplDisplay *pdpy, EplSurface *psurf);
+EplQueryResult eplWlQuerySurface(EplDisplay *pdpy, EplSurface *psurf, EGLint attrib, EGLint *ret_value);
 
 #endif // WAYLAND_PLATFORM_H

--- a/src/wayland/wayland-surface.c
+++ b/src/wayland/wayland-surface.c
@@ -1648,14 +1648,22 @@ EGLBoolean eplWlWaitGL(EplDisplay *pdpy, EplSurface *psurf)
     return ret;
 }
 
-EGLint eplWlQueryBufferAge(EplDisplay *pdpy, EplSurface *psurf)
+EplQueryResult eplWlQuerySurface(EplDisplay *pdpy, EplSurface *psurf, EGLint attrib, EGLint *ret_value)
 {
-    if (psurf->priv->current.swapchain->prime)
+    if (attrib == EGL_BUFFER_AGE_KHR)
     {
-        return 0;
+        if (psurf->priv->current.swapchain->prime)
+        {
+            *ret_value = 0;
+        }
+        else
+        {
+            *ret_value = psurf->priv->current.swapchain->current_back->buffer_age;
+        }
+        return EPL_QUERY_RESULT_SUCCESS;
     }
     else
     {
-        return psurf->priv->current.swapchain->current_back->buffer_age;
+        return EPL_QUERY_RESULT_UNKNOWN;
     }
 }


### PR DESCRIPTION
This generalizes the `EplImplFuncs::QueryBufferAge` function in the base library so that it can handle any platform-specific attributes, not just `EGL_BUFFER_AGE_KHR`.

The behavior for handling `EGL_BUFFER_AGE_KHR` is still the same, and the base library still handles all of the error checking. This just allows the platform-specific code to add additional attributes.

Although egl-wayland2 doesn't currently provide any other attributes for eglQuerySurface, egl-x11 does, so we'll need this to keep the base library working for both. The corresponding update for egl-x11 is here:
https://github.com/NVIDIA/egl-x11/pull/21