### PR TITLE
fix parameter validation

### DIFF
--- a/src/base/config-list.c
+++ b/src/base/config-list.c
@@ -258,6 +258,14 @@ EplConfig **eplConfigListChooseConfigs(EplPlatformData *platform, EGLDisplay edp
             }
             else if (attribs[i] == EGL_NATIVE_RENDERABLE)
             {
+                if (attribs[i + 1] != EGL_TRUE && attribs[i + 1] != EGL_FALSE
+                        && attribs[i + 1] != EGL_DONT_CARE)
+                {
+                    eplSetError(platform, EGL_BAD_ATTRIBUTE,
+                            "Invalid value 0x%04x for EGL_NATIVE_RENDERABLE", attribs[i + 1]);
+                    goto done;
+                }
+
                 nativeRenderable = attribs[i + 1];
             }
             else if (attribs[i] == EGL_NATIVE_VISUAL_TYPE)

--- a/src/base/platform-base.c
+++ b/src/base/platform-base.c
@@ -1268,6 +1268,13 @@ static EGLBoolean HookSwapInterval(EGLDisplay edpy, EGLint interval)
         return EGL_FALSE;
     }
 
+    if (pdpy->platform->egl.GetCurrentContext() == EGL_NO_CONTEXT)
+    {
+        eplSetError(pdpy->platform, EGL_BAD_CONTEXT, "eglSwapInterval called without a current context");
+        eplDisplayRelease(pdpy);
+        return EGL_FALSE;
+    }
+
     if (pdpy->platform->egl.GetCurrentDisplay() == edpy)
     {
         EGLSurface esurf = pdpy->platform->egl.GetCurrentSurface(EGL_DRAW);


### PR DESCRIPTION
Add missing validation for EGL_NATIVE_RENDERABLE to eglChooseConfig.

Check if current thread has an EGL context attached in eglSwapInterval and return EGL_BAD_CONTEXT if not.

Fixes dEQP-EGL.functional.negative_api.*