### PR TITLE
Store presentation timestamps in nanoseconds

### DIFF
--- a/src/wayland/wayland-surface.c
+++ b/src/wayland/wayland-surface.c
@@ -1182,7 +1182,8 @@ static void on_wp_presentation_feedback_presented(void *userdata,
 
     assert(wfeedback == psurf->priv->current.presentation_feedback);
 
-    psurf->priv->current.last_present_timestamp = (((uint64_t) tv_sec_hi) << 32 | tv_sec_lo) + tv_nsec;
+    psurf->priv->current.last_present_timestamp =
+        ((((uint64_t) tv_sec_hi) << 32) | tv_sec_lo) * 1000000000 + tv_nsec;
     psurf->priv->current.last_present_refresh = refresh;
 
     wp_presentation_feedback_destroy(psurf->priv->current.presentation_feedback);


### PR DESCRIPTION
The wp_presentation_feedback::presented handler combined the seconds and nanoseconds fields with simple addition. last_present_timestamp is later used as a nanosecond timestamp for commit timing, so storing seconds plus nanoseconds produced values in mixed units and could schedule future commits with incorrect timing.

Convert the 64-bit presentation seconds value to nanoseconds before adding tv_nsec. This matches the discard path and keeps last_present_timestamp in the units expected by the commit-timing calculation.