### PR TITLE
Fix dmabuf feedback tranche handling in wayland-surface

### DIFF
--- a/src/wayland/wayland-surface.c
+++ b/src/wayland/wayland-surface.c
@@ -381,11 +381,15 @@ static void OnSurfaceFeedbackTrancheDone(void *userdata,
         for (i=0; i<psurf->priv->driver_format->num_modifiers; i++)
         {
             state->modifiers_supported[i] = state->tranche_modifiers_supported[i];
-            state->tranche_modifiers_supported[i] = EGL_FALSE;
         }
         state->linear_supported = state->tranche_linear_supported;
-        state->tranche_linear_supported = EGL_FALSE;
     }
+
+    for (i=0; i<psurf->priv->driver_format->num_modifiers; i++)
+    {
+        state->tranche_modifiers_supported[i] = EGL_FALSE;
+    }
+    state->tranche_linear_supported = EGL_FALSE;
 
     eplWlDmaBufFeedbackCommonTrancheDone(&state->base);
 }

--- a/src/wayland/wayland-surface.c
+++ b/src/wayland/wayland-surface.c
@@ -368,7 +368,7 @@ static void OnSurfaceFeedbackTrancheDone(void *userdata,
     {
         for (i=0; i<psurf->priv->inst->render_device_id_count; i++)
         {
-            if (state->base.tranche_target_device != psurf->priv->inst->render_device_id[i])
+            if (state->base.tranche_target_device == psurf->priv->inst->render_device_id[i])
             {
                 use_tranche = EGL_TRUE;
                 break;


### PR DESCRIPTION
Two related fixes to `OnSurfaceFeedbackTranche*` handling in `src/wayland/wayland-surface.c`. Together they restore the intended behavior of selecting per-surface modifiers from the compositor's dmabuf feedback instead of silently falling back to `PickDefaultModifiers`.
