### PR TITLE
Close dma-buf fd on swapchain creation failure

### DIFF
--- a/src/wayland/wayland-swapchain.c
+++ b/src/wayland/wayland-swapchain.c
@@ -398,7 +398,6 @@ WlSwapChain *eplWlSwapChainCreate(WlDisplayInstance *inst, struct wl_surface *ws
         // linear present buffers. We don't need to create any present buffers
         // yet -- we can do that in the first call to eglSwapBuffers.
         swapchain->modifier = DRM_FORMAT_MOD_LINEAR;
-        close(dmabuf);
     }
     else
     {
@@ -407,6 +406,9 @@ WlSwapChain *eplWlSwapChainCreate(WlDisplayInstance *inst, struct wl_surface *ws
         swapchain->modifier = gbm_bo_get_modifier(gbo);
         swapchain->current_back = SwapChainAppendPresentBuffer(inst, swapchain,
                 dmabuf, gbm_bo_get_stride(gbo), gbm_bo_get_offset(gbo, 0));
+        // SwapChainAppendPresentBuffer takes ownership of the fd in both the
+        // success and failure cases.
+        dmabuf = -1;
         if (swapchain->current_back == NULL)
         {
             goto done;
@@ -421,6 +423,10 @@ done:
     {
         eplWlSwapChainDestroy(inst, swapchain);
         swapchain = NULL;
+    }
+    if (dmabuf >= 0)
+    {
+        close(dmabuf);
     }
     if (gbo != NULL)
     {


### PR DESCRIPTION
eplWlSwapChainCreate obtains a dma-buf fd from gbm_bo_get_fd() and then hands it to PlatformImportColorBufferNVX, which does not take ownership of the fd. If that import failed, the function jumped to the cleanup label without closing the fd, leaking one file descriptor per failed swapchain creation.

Track ownership explicitly and clear `dmabuf` once it has been handed off, and close it at the cleanup label if it is still owned by this function.