### PR TITLE
Return NULL, not EGL_FALSE, from eplWlHookQueryString

### DIFF
--- a/src/wayland/wayland-display.c
+++ b/src/wayland/wayland-display.c
@@ -1219,7 +1219,7 @@ const char *eplWlHookQueryString(EGLDisplay edpy, EGLint name)
 
     if (pdpy == NULL)
     {
-        return EGL_FALSE;
+        return NULL;
     }
 
     if (name == EGL_EXTENSIONS)


### PR DESCRIPTION
eplWlHookQueryString returns `const char *`, but the display-acquire-failure path returned `EGL_FALSE`. EGL_FALSE is 0 and implicitly converts to a null pointer, so behavior is unchanged, but the return value is misleading to readers and to static analysis. Return NULL to match the declared type.