### PR TITLE
Don't send a wl_surface::frame request if the swap interval is zero

### DIFF
--- a/src/wayland/wayland-surface.c
+++ b/src/wayland/wayland-surface.c
@@ -1387,11 +1387,7 @@ EGLBoolean eplWlSwapBuffers(EplPlatformData *plat, EplDisplay *pdpy,
             // presentation time.
             DiscardPresentationFeedback(psurf);
         }
-        if (psurf->priv->current.frame_callback != NULL)
-        {
-            wl_callback_destroy(psurf->priv->current.frame_callback);
-            psurf->priv->current.frame_callback = NULL;
-        }
+
         if (psurf->priv->current.last_swap_sync != NULL)
         {
             wl_callback_destroy(psurf->priv->current.last_swap_sync);
@@ -1400,7 +1396,6 @@ EGLBoolean eplWlSwapBuffers(EplPlatformData *plat, EplDisplay *pdpy,
     }
 
     assert(psurf->priv->current.presentation_feedback == NULL);
-    assert(psurf->priv->current.frame_callback == NULL);
     assert(psurf->priv->current.last_swap_sync == NULL);
 
     if (rects != NULL && n_rects > 0
@@ -1499,10 +1494,22 @@ EGLBoolean eplWlSwapBuffers(EplPlatformData *plat, EplDisplay *pdpy,
             wp_fifo_v1_wait_barrier(psurf->priv->current.fifo);
         }
     }
-    else
+    else if (swap_interval > 0)
     {
-        // If we don't have FIFO or presentation time support, then just
-        // request a frame callback.
+        /*
+         * If we don't have FIFO or presentation time support, then just
+         * request a frame callback.
+         *
+         * Only send that request if the swap interval is non-zero, though.
+         * Since the server can wait indefinitely before sending the response,
+         * and since wl_callback doesn't have a destroy request, sending a
+         * wl_surface::frame request every frame without waiting for them could
+         * create an unbounded number of pending wl_callbacks in the server.
+         */
+
+        // If swap_interval is nonzero, then we should have called
+        // WaitForPreviousFrames above, which would clear frame_callback.
+        assert(psurf->priv->current.frame_callback == NULL);
         psurf->priv->current.frame_callback = wl_surface_frame(psurf->priv->current.wsurf);
         if (psurf->priv->current.frame_callback != NULL)
         {


### PR DESCRIPTION
This is a fix for bug #41, where if the swap interval is zero, egl-wayland2 sends `wl_surface::frame` requests at every frame, but then on the next frame, it just destroys the `wl_callback` proxy without waiting for it.

Even if we destroy the proxy in the client, the `wl_callback` still exists on the server, and if the window isn't visible, then the server could delay sending the callback event indefinitely. As a result, the number of pending callbacks can grow without bound.

To fix that, this changes the eglSwapBuffers implementation so that if the current swap interval is zero, then it doesn't send a new `wl_surface::frame` request, and it doesn't wait for or destroy any pending callback.

That way, it'll never have more than one outstanding frame callback at any one time. A swap interval of zero will work correctly, since it'll never wait on a previous frame.

A swap interval of one will work as correctly as it can without wp_fifo, in that it'll wait for the previous frame's callback before trying to commit the next frame.

The place where it doesn't quite work right is if you change the swap interval from 1 to 0 and then back to 1 -- in that case, before it commits frame 3, it'll wait on frame 1, not on frame 2.

But, that's a pretty weird corner case, and without wp_fifo, actual FIFO semantics are always going to be some degree of broken anyway. This way, they're at least broken in a way that doesn't risk resource exhaustion.