### PR TITLE
Bind the fifo-v1 and presentaion-time globals if commit-timing-v1 is …

### DIFF
--- a/src/wayland/wayland-display.c
+++ b/src/wayland/wayland-display.c
@@ -1072,8 +1072,7 @@ WlDisplayInstance *eplWlDisplayInstanceCreate(EplDisplay *pdpy, EGLBoolean from_
     }
 
     if (names.wp_presentation.name != 0
-            && names.wp_fifo_manager_v1.name != 0
-            && names.wp_commit_timing_manager_v1.name != 0)
+            && names.wp_fifo_manager_v1.name != 0)
     {
         inst->globals.presentation_time = BindGlobalObject(names.registry,
                 names.wp_presentation.name, &wp_presentation_interface,
@@ -1098,7 +1097,10 @@ WlDisplayInstance *eplWlDisplayInstanceCreate(EplDisplay *pdpy, EGLBoolean from_
         {
             goto done;
         }
+    }
 
+    if (names.wp_commit_timing_manager_v1.name != 0)
+    {
         inst->globals.commit_timing = BindGlobalObject(names.registry,
                 names.wp_commit_timing_manager_v1.name, &wp_commit_timing_manager_v1_interface,
                 names.wp_commit_timing_manager_v1.version, NULL);


### PR DESCRIPTION
…not present

The fifo presentation path requires the fifo-v1 and presentation-time protocols, while commit-timing-v1 is optional. Don't require the presence of commit-timing-v1 to bind the fifo-v1 and presentation-time globals.

This allows the fifo presentation path to function on KDE/KWin, which implements fifo-v1 and presentation-time, but does not (yet) implement the commit-timing-v1 protocol.