### PR TITLE
base: Add DRM_FORMAT_XBGR16161616F to the format list

### DIFF
--- a/src/base/config-list.c
+++ b/src/base/config-list.c
@@ -42,6 +42,7 @@ const EplFormatInfo FORMAT_INFO_LIST[] =
     { DRM_FORMAT_ARGB2101010, 32, { 10, 10, 10, 2 }, { 20, 10, 0, 30 } },
     { DRM_FORMAT_ABGR2101010, 32, { 10, 10, 10, 2 }, { 0, 10, 20, 30 } },
     { DRM_FORMAT_ABGR16161616F, 64, { 16, 16, 16, 16 }, {  0, 16, 32, 48 } },
+    { DRM_FORMAT_XBGR16161616F, 64, { 16, 16, 16,  0 }, {  0, 16, 32,  0 } },
 
     /* 8 bpp RGB */
     { DRM_FORMAT_RGB332, 8, { 3, 3, 2, 0 }, { 5, 2, 0, 0 } },


### PR DESCRIPTION
This adds an entry for `DRM_FORMAT_XBGR16161616F` to the format list in the base library. Currently, we only have `DRM_FORMAT_ABGR16161616F`, which means that if the app uses EGL_PRESENT_OPAQUE_EXT with an ARGB16F config, it won't be able to find the corresponding opaque format.