### PR TITLE
Use `wl_array_init` instead of `.size = 0`

### DIFF
--- a/src/wayland/wayland-dmabuf.c
+++ b/src/wayland/wayland-dmabuf.c
@@ -169,7 +169,7 @@ static WlFormatList *FinishDefaultFeedback(DefaultFeedbackState *state, dev_t *r
         if (tranche->target_device != state->base.main_device)
         {
             wl_array_release(&tranche->formats);
-            tranche->formats.size = 0;
+            wl_array_init(&tranche->formats);
             continue;
         }
 


### PR DESCRIPTION
`wl_array_release` does not check `size` before calling `free`, so if the `ptr` field is not also set to `0`, `wl_array_release` will segfault in `FinishDefaultFeedback` freeing `WL_ARRAY_POISON_PTR`.