### PR TITLE
wayland: Bound protocol override separator search

### DIFF
--- a/src/wayland/wayland-display.c
+++ b/src/wayland/wayland-display.c
@@ -334,7 +334,7 @@ static ProtocolVersionOverride *ParseProtocolOverrideString(const char *str)
     num_tokens = 0;
     while (FindNextStringToken(&tok, &len, ","))
     {
-        const char *sep = strchr(tok, '=');
+        const char *sep = memchr(tok, '=', len);
         if (sep != NULL)
         {
             size_t namelen = (sep - tok);


### PR DESCRIPTION
Limit the search for the '=' separator to the current comma-delimited protocol override token.

The existing strchr call can find an '=' in a later token. This makes the calculated name length exceed the space reserved for that token and can cause a heap buffer overflow in memcpy.

The issue was reproduced through the __NV_WAYLAND_PROTOCOL_VERSIONS environment variable with the following value:

a,b,c,d,e,f,g,h,i,j=1

An ASan and UBSan instrumented standalone harness containing the parser implementation reported a heap-buffer-overflow and a write of size 17 in memcpy with the original strchr implementation.

With the same input, the patched memchr implementation completed successfully and parsed one entry without sanitizer errors.

The complete project also builds successfully with Meson's address and undefined behavior sanitizers enabled. The project currently has no Meson tests.